### PR TITLE
Rename date to startDate in milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ const milestones = ref([
   {
     id: 101,
     name: '项目立项',
-    date: '2025-01-01',
+    startDate: '2025-01-01',
     type: 'milestone',
   },
 ])


### PR DESCRIPTION
修复了README中快速开始的第一个示例代码里的milestones数据源中字段名笔误，将错误的字段修正为startDate