### PR TITLE
fix: replace hardcoded Chinese strings with i18n translations

### DIFF
--- a/src/components/ConfirmTimerDialog.vue
+++ b/src/components/ConfirmTimerDialog.vue
@@ -3,10 +3,10 @@ import { ref, watch, computed } from 'vue'
 import { useI18n } from '../composables/useI18n'
 const props = defineProps({
   visible: Boolean,
-  title: { type: String, default: '确认开始计时' },
+  title: { type: String, default: '' },
   message: { type: String, default: '' },
   defaultDesc: { type: String, default: '' },
-  placeholder: { type: String, default: '请输入计时说明' },
+  placeholder: { type: String, default: '' },
 })
 
 const emit = defineEmits(['confirm', 'cancel'])

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -19,15 +19,11 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
   modelValue: '',
   type: 'date',
-  placeholder: '请选择日期',
-  startPlaceholder: '开始日期',
-  endPlaceholder: '结束日期',
   disabled: false,
   clearable: true,
   size: 'default',
   format: 'YYYY-MM-DD',
   valueFormat: 'YYYY-MM-DD',
-  rangeSeparator: '至',
 })
 
 const emit = defineEmits<{
@@ -38,6 +34,12 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+
+// Effective prop values — fall back to i18n translations when prop is not provided
+const effectivePlaceholder = computed(() => props.placeholder ?? t.value.selectDate)
+const effectiveStartPlaceholder = computed(() => props.startPlaceholder ?? t.value.startDate)
+const effectiveEndPlaceholder = computed(() => props.endPlaceholder ?? t.value.endDate)
+const effectiveRangeSeparator = computed(() => props.rangeSeparator ?? t.value.to)
 
 // 内部状态
 const isFocused = ref(false)
@@ -107,7 +109,7 @@ const displayValue = computed(() => {
       : ''
     const end = endValue.value ? formatDisplayDateTime(endValue.value, selectedTime.value) : ''
     if (start && end) {
-      return `${start} ${props.rangeSeparator} ${end}`
+      return `${start} ${effectiveRangeSeparator.value} ${end}`
     }
     return start || end || ''
   }
@@ -967,8 +969,8 @@ const timePickerStyle = computed(() => {
             class="el-input__inner-input"
             :placeholder="
               type === 'daterange'
-                ? `${startPlaceholder} ${rangeSeparator} ${endPlaceholder}`
-                : placeholder
+                ? `${effectiveStartPlaceholder} ${effectiveRangeSeparator} ${effectiveEndPlaceholder}`
+                : effectivePlaceholder
             "
             :disabled="disabled"
             readonly

--- a/src/components/TaskContextMenu.vue
+++ b/src/components/TaskContextMenu.vue
@@ -467,8 +467,8 @@ defineExpose({ menuRef })
       <ConfirmTimerDialog
         v-if="showTimerConfirm"
         :visible="showTimerConfirm"
-        :title="'确认开始计时'"
-        :message="`即将为任务${props.task?.name}计时，若有特殊说明请完善下面的描述`"
+        :title="t.startTimer"
+        :message="`${t.timerConfirmPrefix}${props.task?.name}${t.timerConfirmSuffix}`"
         :default-desc="props.task?.name || ''"
         @confirm="confirmTimer"
         @cancel="cancelTimerConfirm"

--- a/src/components/TaskDrawer.vue
+++ b/src/components/TaskDrawer.vue
@@ -1328,8 +1328,8 @@ const taskStatus = computed(() => {
     <ConfirmTimerDialog
       v-if="showTimerConfirm"
       :visible="showTimerConfirm"
-      :title="'确认开始计时'"
-      :message="`即将为任务${props.task?.name}计时，若有特殊说明请完善下面的描述`"
+      :title="t.startTimer"
+      :message="`${t.timerConfirmPrefix}${props.task?.name}${t.timerConfirmSuffix}`"
       :default-desc="props.task?.name || ''"
       @confirm="confirmTimer"
       @cancel="cancelTimerConfirm"

--- a/src/composables/useI18n.ts
+++ b/src/composables/useI18n.ts
@@ -177,6 +177,9 @@ const messages = {
     selectTime: '选择时间',
     hour: '时',
     minute: '分',
+    // 日期选择器占位符
+    selectDate: '请选择日期',
+    to: '至',
     noParentTask: '无上级任务',
     update: '更新',
     taskNameTooLong: '任务名称不能超过50个字符',
@@ -489,7 +492,9 @@ const messages = {
     selectTime: 'Select Time',
     hour: 'Hour',
     minute: 'Minute',
-
+    // Date picker placeholders
+    selectDate: 'Select date',
+    to: 'to',
     noParentTask: 'No Parent Task',
     update: 'Update',
     taskNameTooLong: 'Task name cannot exceed 50 characters',


### PR DESCRIPTION
## 问题描述

组件库中存在硬编码的中文字符串，导致切换到英文（或其他语言）时，部分 UI 文本仍显示为中文，无法跟随语言设置变化。

## 修改内容

### `useI18n.ts`
新增两个缺失的翻译键，用于支持 `DatePicker` 的 i18n 回退：
- `selectDate`：日期选择器占位符（中文：`请选择日期` / 英文：`Select date`）
- `to`：日期范围分隔符（中文：`至` / 英文：`to`）

### `DatePicker.vue`
- 移除 `withDefaults` 中的硬编码中文默认值（`placeholder`、`startPlaceholder`、`endPlaceholder`、`rangeSeparator`）
- 新增四个 computed 属性作为回退，当 prop 未传入时自动读取当前语言的翻译：
  ```ts
  const effectivePlaceholder = computed(() => props.placeholder ?? t.value.selectDate)
  const effectiveStartPlaceholder = computed(() => props.startPlaceholder ?? t.value.startDate)
  const effectiveEndPlaceholder = computed(() => props.endPlaceholder ?? t.value.endDate)
  const effectiveRangeSeparator = computed(() => props.rangeSeparator ?? t.value.to)
  ```

### `ConfirmTimerDialog.vue`
- 移除 `title` 和 `placeholder` prop 的硬编码中文默认值（这两个 prop 在模板中未被使用，模板已直接通过 `t()` 获取翻译）

### `TaskContextMenu.vue` / `TaskDrawer.vue`
- 将硬编码的中文字符串替换为 i18n 翻译：
  ```diff
  - :title="'确认开始计时'"
  - :message="`即将为任务${props.task?.name}计时，若有特殊说明请完善下面的描述`"
  + :title="t.startTimer"
  + :message="`${t.timerConfirmPrefix}${props.task?.name}${t.timerConfirmSuffix}`"
  ```

## 测试

已在本地执行 `npm run build`，构建通过，无报错，无破坏性变更。

## 备注

所有修改均向后兼容——调用方若已显式传入上述 prop，行为不受影响；仅在未传入时才会回退到当前语言的翻译文本。

感谢您开发并维护这个优秀的组件库！如有任何问题或建议，欢迎随时反馈。🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)